### PR TITLE
proposal

### DIFF
--- a/libwarpaffine/brick.h
+++ b/libwarpaffine/brick.h
@@ -19,7 +19,6 @@ struct BrickInfo
     std::uint32_t       depth;          ///< The depth of the brick in pixels.
     std::uint32_t       stride_line;    ///< The stride of a line in bytes.
     std::uint32_t       stride_plane;   ///< The stride of a slice (aka plane) in bytes.
-    std::int32_t        slice_id;       ///< The slice id. This will be used to identify subblocks that originate from the same brick.
 
     /// Gets size of the brick in bytes. This is only counting the "payload" data.
     /// \returns The (payload) size of the brick in bytes.

--- a/libwarpaffine/dowarp.h
+++ b/libwarpaffine/dowarp.h
@@ -68,13 +68,15 @@ class DoWarp
         /// index.
         struct DestinationBrickInfo
         {
-            IntCuboid   cuboid;
+            std::uint32_t brick_id;  ///< This id uniquely identifies the destination brick, and since there is a one-to-one correspondence between source and destination bricks, 
+                                     ///< it also uniquely identifies the source brick.
+            IntCuboid cuboid;
             std::vector<TilingRectAndMandSceneIndex> tiling;
-            int slice_id;
         };
     private:
         std::map<BrickInPlaneIdentifier, DestinationBrickInfo> map_brickid_destinationbrickinfo_;
         std::uint32_t number_of_subblocks_to_output_{ 0 };
+        bool has_there_been_a_retiling_on_any_destination_brick_{ false };
     public:
         OutputBrickInfoRepository(const AppContext& context, const DeskewDocumentInfo& document_info, const Eigen::Matrix4d& transformation_matrix);
 
@@ -91,6 +93,12 @@ class DoWarp
         ///
         /// \returns The total number of subblocks to output.
         [[nodiscard]] std::uint32_t GetTotalNumberOfSubblocksToOutput() const;
+
+        /// Query whether there has been a retiling on any destination brick. This is intended to be used in order to
+        /// decide whether it is necessary to have a retiling-id in the output document.
+        ///
+        /// \returns    True if there been retiling on any destination brick, false if not.
+        [[nodiscard]] bool HasThereBeenRetilingOnAnyDestinationBrick() const { return this->has_there_been_a_retiling_on_any_destination_brick_; };
     private:
         static std::vector<libCZI::IntRect> Create2dTiling(std::uint32_t max_extent, const libCZI::IntRect& rectangle);
     };
@@ -162,7 +170,6 @@ public:
     bool TryGetHash(std::array<uint8_t, 16>* hash_code) const;
 private:
     void InputBrick(const Brick& brick, const BrickCoordinateInfo& coordinate_info);
-private:
     std::vector<ITaskArena::SuspendHandle> resume_handles_;
     std::mutex mutex_resume_handles_;
 
@@ -172,7 +179,7 @@ private:
         int z_slice;
     };
 
-    void ProcessOutputSlice(OutputSliceToCompressTaskInfo* output_slice_task_info, const libCZI::CDimCoordinate& coordinate, const SubblockXYM& xym);
+    void ProcessOutputSlice(OutputSliceToCompressTaskInfo* output_slice_task_info, const libCZI::CDimCoordinate& coordinate, const SubblockXYM& xym, std::uint32_t source_brick_id);
 
     void IncWarpTasksInFlight();
     void DecWarpTasksInFlight();
@@ -184,9 +191,9 @@ private:
     bool IsSubTilingRequired(const IntSize3& size);
     std::vector<libCZI::IntRect> Create2dTiling(const libCZI::IntRect& rectangle);
     Brick CreateBrick(libCZI::PixelType pixel_type, std::uint32_t width, std::uint32_t height, std::uint32_t depth);
-    Brick CreateBrickAndWaitUntilAvailable(libCZI::PixelType pixel_type, std::uint32_t width, std::uint32_t height, std::uint32_t depth, int slice_id);
+    Brick CreateBrickAndWaitUntilAvailable(libCZI::PixelType pixel_type, std::uint32_t width, std::uint32_t height, std::uint32_t depth/*, int slice_id*/);
 
-    void ProcessBrickCommon2(const Brick& brick, const Brick& destination_brick, const BrickCoordinateInfo& coordinate_info, std::uint32_t source_depth, const OutputBrickInfoRepository::TilingRectAndMandSceneIndex& rect_and_tile_identifier /*const libCZI::IntRect& roi,  int m_index*/);
+    void ProcessBrickCommon2(const Brick& brick, std::uint32_t brick_id, const Brick& destination_brick, const BrickCoordinateInfo& coordinate_info, std::uint32_t source_depth, const OutputBrickInfoRepository::TilingRectAndMandSceneIndex& rect_and_tile_identifier);
 
     std::tuple<libCZI::CompressionMode, std::shared_ptr<libCZI::IMemoryBlock>> Compress(const OutputSliceToCompressTaskInfo& output_slice_task_info);
 

--- a/libwarpaffine/geotypes.h
+++ b/libwarpaffine/geotypes.h
@@ -108,5 +108,4 @@ struct SubblockXYM
     int y_position{ 0 };
     std::optional<int> m_index;         ///< The m-index of the subblock.
     std::optional<int> scene_index;     ///< The scene-index of the subblock.
-    int slice_id;
 };

--- a/libwarpaffine/sliceswriter/ISlicesWriter.h
+++ b/libwarpaffine/sliceswriter/ISlicesWriter.h
@@ -50,8 +50,9 @@ public:
         /// The Y-position of the subblock.
         int y_position{ 0 };
 
-        /// The ID of the slice
-        int slice_id;
+        /// The brick-id this slice belongs to. If present AND the writer supports it, this id
+        /// together with the z-index will be used to construct a retiling-id for the subblock.
+        std::optional<std::uint32_t> brick_id;
     };
 
     /// Gets number of currently pending slice write operations.

--- a/libwarpaffine/sliceswriter/SlicesWriterTbb.cpp
+++ b/libwarpaffine/sliceswriter/SlicesWriterTbb.cpp
@@ -80,11 +80,11 @@ void CziSlicesWriterTbb::WriteWorker()
             add_subblock_info.ptrData = sub_block_write_info.add_slice_info.subblock_raw_data->GetPtr();
             add_subblock_info.dataSize = sub_block_write_info.add_slice_info.subblock_raw_data->GetSizeOfData();
 
-            if (this->use_acquisition_tiles_) 
+            if (sub_block_write_info.add_slice_info.brick_id.has_value() && this->use_acquisition_tiles_)
             {
                 int z;
                 sub_block_write_info.add_slice_info.coordinate.TryGetPosition(libCZI::DimensionIndex::Z, &z);
-                auto guid = this->CreateRetilingIdWithZandSlice(z, sub_block_write_info.add_slice_info.slice_id);
+                auto guid = this->CreateRetilingIdWithZandSlice(z, sub_block_write_info.add_slice_info.brick_id.value());
 
                 std::ostringstream oss;
                 oss << "<METADATA><Tags><RetilingId>"
@@ -105,7 +105,7 @@ void CziSlicesWriterTbb::WriteWorker()
 
                 const string metadata_xml = oss.str();
                 add_subblock_info.ptrSbBlkMetadata = metadata_xml.c_str();
-                add_subblock_info.sbBlkMetadataSize = metadata_xml.size();
+                add_subblock_info.sbBlkMetadataSize = static_cast<uint32_t>(metadata_xml.size());
 
                 this->writer_->SyncAddSubBlock(add_subblock_info);
             }
@@ -143,8 +143,8 @@ void CziSlicesWriterTbb::WriteWorker()
     }
 }
 
-libCZI::GUID CziSlicesWriterTbb::CreateRetilingIdWithZandSlice(int z, int slice) 
-const {
+libCZI::GUID CziSlicesWriterTbb::CreateRetilingIdWithZandSlice(int z, uint32_t slice) const
+{
     libCZI::GUID guid = this-> retilingBaseId_;
     guid.Data4[0] = static_cast<uint8_t>(z >> 24);
     guid.Data4[1] = static_cast<uint8_t>(z >> 16);

--- a/libwarpaffine/sliceswriter/SlicesWriterTbb.h
+++ b/libwarpaffine/sliceswriter/SlicesWriterTbb.h
@@ -49,5 +49,5 @@ public:
 private:
     void WriteWorker();
     void CopyMetadata(libCZI::IXmlNodeRead* rootSource, libCZI::IXmlNodeRw* rootDestination);
-    libCZI::GUID CreateRetilingIdWithZandSlice(int z, int slice) const;
+    libCZI::GUID CreateRetilingIdWithZandSlice(int z, std::uint32_t slice) const;
 };


### PR DESCRIPTION
I tried to work out the suggestions given [here](https://github.com/ZEISS/warpaffine/pull/6#issuecomment-2192773347).

* It is not longer necessary to have "slice_id" added to `BrickInfo` or `SubBlockXYM`.
* Renamed "slice_id" to "brick_id" - not completely happy with this name, but seems more suggestive to me
* added logic so that retiling-id is only written (into the resulting CZI) if there is necessity